### PR TITLE
イベント閲覧機能の作成

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,5 @@
 class EventsController < ApplicationController
+  skip_before_action :authenticate, only: :show
 
   def new
     @event = current_user.created_events.build
@@ -9,6 +10,10 @@ class EventsController < ApplicationController
     if @event.save
       redirect_to @event, notice: "作成しました"
     end
+  end
+
+  def show
+    @event = Event.find(params[:id])
   end
 
   private

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,6 +2,7 @@ class WelcomeController < ApplicationController
   skip_before_action :authenticate
 
   def index
+    @event = Event.where("start_at > ?", Time.zone.now).order(:start_at)
   end
   
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ApplicationRecord
+  belongs_to :owner, class_name: "User"
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -1,0 +1,7 @@
+%h1 イベント一覧
+
+%ul.list-group
+  - @events.each do |event|
+    = link_to(event, class: "list-group-item list-group-item-action") do
+      %h5.list-group-item-heading= event.name
+      %p.mb-1= "#{|(event.start_at, format: :long)} - #{|(event.end_at, format: :long)}"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,0 +1,20 @@
+%h1.mt-3.mb-3= @event.name
+.card.mb-2
+  %h5.card-header イベント内容
+  .card-body
+    %p.card-text= @event.content
+.card.mb-2
+  %h5.card-header 開催時間
+  .card-body
+    %p.card-text= "#{|(@event.start_at, format: :long)} - #{|(@event..end_at, format: :long)}" #
+
+.card.mb-2
+  %h5.card-header 開催場所
+  .card-body
+    %p.card-text= @event.place
+.card.mb-2
+  %h5.card-header 主催者
+    %p.card-body
+      = link_to("https://github.com/#{@event.owner.name}", class: "card-link") do #
+        = image_tag @event.owner.image_url, width: 50, height: 50
+        = "@#{@event.owner.name}"


### PR DESCRIPTION
# what
イベントを登録した時に、イベント詳細ページに遷移する
トップページに、未開催のイベント一覧が表示される
イベント一覧からイベント詳細ページに遷移できる
# why
イベントの閲覧機能を作る