### PR TITLE
イベントの編集機能の拡張

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -16,6 +16,23 @@ class EventsController < ApplicationController
     @event = Event.find(params[:id])
   end
 
+  def edit
+    @event = current_user.created_events.find(params[:id])
+  end
+
+  def update
+    @event = current_user.created_events.find(params[:id])
+    if @event.update(event_params)
+      redirect_to @event, notice: "更新しました"
+    end
+  end
+
+  def destroy
+    @event = current_user.created_events.find(params[:id])
+    @event.destroy!
+    redirect_to root_path, notice: "削除しました"
+  end
+
   private
 
   def event_params

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -7,6 +7,11 @@ class Event < ApplicationRecord
   validates :end_at, presence:true
   validate :start_at_should_be_before_end_at
 
+  def created_by?(user)
+    return false unless user
+      owner_id == user.id
+  end
+
   private
 
   def start_at_should_be_before_end_at
@@ -16,4 +21,6 @@ class Event < ApplicationRecord
         errors.add(:start_at, "は終了時間よりも前に設定してください")
     end
   end
+
+
 end

--- a/app/views/events/edit.html.haml
+++ b/app/views/events/edit.html.haml
@@ -1,0 +1,24 @@
+- now = Time.zone.now
+
+%h1.mt-2 イベント情報編集
+
+= form_with(model: @event, class: "form-horizontal") do |f|
+  #errors
+  .form-group
+    = f.label :name
+    = f.text_field :name, class: "form-control"
+  .form-group
+    = f.label :place
+    = f.text_field :place, class: "form-control"
+  .form-group
+    = f.label :start_at
+    %div
+      = f.datetime_select :start_at, start_year: now.year, end_year: now.year + 1
+  .form-group
+    = f.label :end_at
+    %div
+      = f.datetime_select :end_at, start_year: now.year, end_year: now.year + 1
+  .form-group
+    = f.label :content
+    = f.text_area :content, class: "form-control", row: 10
+  = f.submit class: "btn btn-primary"

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -1,20 +1,26 @@
 %h1.mt-3.mb-3= @event.name
-.card.mb-2
-  %h5.card-header イベント内容
-  .card-body
-    %p.card-text= @event.content
-.card.mb-2
-  %h5.card-header 開催時間
-  .card-body
-    %p.card-text= "#{|(@event.start_at, format: :long)} - #{|(@event..end_at, format: :long)}" #
+.row
+  .col-8
+    .card.mb-2
+      %h5.card-header イベント内容
+      .card-body
+        %p.card-text= @event.content
+    .card.mb-2
+      %h5.card-header 開催時間
+      .card-body
+        %p.card-text= "#{l(@event.start_at, format: :long)} - #{l(@event.end_at, format: :long)}" #
 
-.card.mb-2
-  %h5.card-header 開催場所
-  .card-body
-    %p.card-text= @event.place
-.card.mb-2
-  %h5.card-header 主催者
-    %p.card-body
-      = link_to("https://github.com/#{@event.owner.name}", class: "card-link") do #
-        = image_tag @event.owner.image_url, width: 50, height: 50
-        = "@#{@event.owner.name}"
+    .card.mb-2
+      %h5.card-header 開催場所
+      .card-body
+        %p.card-text= @event.place
+    .card.mb-2
+      %h5.card-header 主催者
+      .card-body
+        = link_to("https://github.com/#{@event.owner.name}", class: "card-link") do #
+          = image_tag @event.owner.image_url, width: 50, height: 50
+          = "@#{@event.owner.name}"
+  .col-4
+    - if @event.created_by?(current_user)
+      = link_to "イベントを編集する", edit_event_path(@event), class: "btn btn-info btn-lg btn-block"
+      = link_to "イベントを削除する", event_path(@event), class: "btn btn-danger btn-lg btn-block", method: :delete, date: { confirm: "本当に削除しますか？" }

--- a/app/views/events/update.js.erb
+++ b/app/views/events/update.js.erb
@@ -1,0 +1,1 @@
+document.getElementById("errors").innerHTML = "<%= j render("errors", errors: @event.errors) %>"


### PR DESCRIPTION
# what
イベント詳細ページに「イベントを編集する」リンクを追加する
イベントを編集するをクリックすると、イベント編集フォームに遷移する
イベント編集フォームを間違った情報を入力するとエラーメッセージが表示される
イベント編集フォームで正しく入力するとイベントが更新される
イベント詳細ページにイベントを削除するのリンクを追加する
イベントを削除するのリンクをクリックすると確認ダイアログが表示され、OKするとイベントが削除される
# why
イベントの編集・削除機能の実装